### PR TITLE
Update plasmo version and add multi-threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,54 @@
 # SchwarzSolver
 
-[![Build Status](https://travis-ci.com/jalving/MGSchwarzSolver.jl.svg?branch=master)](https://travis-ci.com/jalving/MGSchwarzSolver.jl)
-[![Codecov](https://codecov.io/gh/jalving/MGSchwarzSolver.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/jalving/MGSchwarzSolver.jl)
+## Overview
+SchwarzSolver.jl implements overlapping Schwarz decomposition to graph-structured optimization problems according to this [paper](https://arxiv.org/abs/1810.00491).  
+The package works with the graph-based algebraic modeling package [Plasmo.jl](https://github.com/zavalab/Plasmo.jl).
+
+## Installation
+SchwarzSolver.jl can be installed using the following Julia Pkg command:
+
+```julia
+using Pkg
+Pkg.add(PackageSpec(url="https://github.com/zavalab/SchwarzSolver.jl.git"))
+```
+
+## Simple Example
+```julia
+using Plasmo, KaHyPar, Ipopt
+using SchwarzSolver
+
+T = 3000          #number of time points
+d = sin.(1:T)     #disturbance vector
+overlap = 5       #overlap distance
+imbalance = 0.1   #partition imbalance
+
+graph = OptiGraph()
+@optinode(graph,state[1:T])
+@optinode(graph,control[1:T-1])
+
+for (i,node) in enumerate(state)
+    @variable(node,x)
+    @constraint(node, x >= 0)
+    @objective(node,Min,0.001*x^2) #- 2*x*d[i])
+end
+for node in control
+    @variable(node,u)
+    @constraint(node, u >= -1000)
+    @objective(node,Min,u^2)
+end
+n1 = state[1]
+@constraint(n1,n1[:x] == 0)
+
+@linkconstraint(graph,links[i = 1:T-1], state[i][:x] + control[i][:u] + d[i] == state[i+1][:x])
+
+#Partition the problem
+hypergraph,hyper_map = gethypergraph(graph) #create hypergraph object based on graph
+partition_vector = KaHyPar.partition(hypergraph,8,configuration = :connectivity,imbalance = imbalance)
+partition = Partition(hypergraph,partition_vector,hyper_map)
+make_subgraphs!(graph,partition)
+
+#Solve directly with expanded subgraphs
+subgraphs = getsubgraphs(graph)
+expanded_subs = expand.(Ref(graph),subgraphs,Ref(5))
+schwarz_solve(graph,expanded_subs;sub_optimizer = optimizer_with_attributes(Ipopt.Optimizer,"tol" => 1e-12,"print_level" => 0),max_iterations = 100,tolerance = 1e-10)
+```

--- a/examples/optimal_control.jl
+++ b/examples/optimal_control.jl
@@ -38,6 +38,3 @@ subgraphs = getsubgraphs(graph)
 expanded_subs = expand.(Ref(graph),subgraphs,Ref(5))
 schwarz_solve(graph,expanded_subs;sub_optimizer = optimizer_with_attributes(Ipopt.Optimizer,"tol" => 1e-12,"print_level" => 0),max_iterations = 100,tolerance = 1e-10,
 dual_links = [],primal_links = [])
-
-# schwarz_solve(graph,overlap;sub_optimizer = optimizer_with_attributes(Ipopt.Optimizer,"tol" => 1e-12,"print_level" => 0),max_iterations = 100,tolerance = 1e-10,
-# dual_links = [],primal_links = [])

--- a/examples/optimal_control.jl
+++ b/examples/optimal_control.jl
@@ -8,9 +8,9 @@ d = sin.(1:T)    #disturbance vector
 overlap = 5
 imbalance = 0.1
 
-graph = ModelGraph()
-@node(graph,state[1:T])
-@node(graph,control[1:T-1])
+graph = OptiGraph()
+@optinode(graph,state[1:T])
+@optinode(graph,control[1:T-1])
 
 for (i,node) in enumerate(state)
     @variable(node,x)

--- a/src/SchwarzSolver.jl
+++ b/src/SchwarzSolver.jl
@@ -3,6 +3,7 @@ module SchwarzSolver
 using Printf
 using DataStructures
 using LinearAlgebra
+import LinearAlgebra: BLAS
 using MathOptInterface
 using Plasmo
 using Ipopt


### PR DESCRIPTION
This PR makes SchwarzSolver.jl compatible with Plasmo v0.3.0 and higher.  It also adds a simple multi-threaded call for the primary iteration loop so subproblems are solved in parallel.